### PR TITLE
Fix transfer typo in syllabus supplies list

### DIFF
--- a/pages/syllabus.md
+++ b/pages/syllabus.md
@@ -135,7 +135,7 @@ Due to the current and advanced nature of this class, it is under constant revis
 
 # Supplies
 * To support class activities and access course materials, a laptop or desktop computer with a webcam and mic is required.
-* A notebook, and pencil. It helps to first scribble your ideas on paper and then tranfer them into an electronic medium for sharing. We will be doing a lot of drawing!
+* A notebook, and pencil. It helps to first scribble your ideas on paper and then transfer them into an electronic medium for sharing. We will be doing a lot of drawing!
 
 # Important Dates
 [See Canvas](https://unomaha.instructure.com/login)


### PR DESCRIPTION
## Summary
- correct the spelling of "transfer" in the syllabus supplies list for clarity

## Testing
- not run (documentation change)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6945a20ef6248320a03183d3c084cd8e)