### PR TITLE
Adjust team slide column widths

### DIFF
--- a/slides/teams-2025/teams.html
+++ b/slides/teams-2025/teams.html
@@ -85,12 +85,15 @@
 
       /* Two-column layout */
       .left-column {
-        width: 50%;
+        width: 48%;
         float: left;
+        margin-right: 4%;
+        box-sizing: border-box;
       }
       .right-column {
-        width: 75%;
-        float: right;
+        width: 48%;
+        float: left;
+        box-sizing: border-box;
       }
 
       /* responsive images */


### PR DESCRIPTION
## Summary
- balance the two-column slide layout widths and spacing to keep combined width within 100%
- add box-sizing safeguards for both columns to prevent overflow

## Testing
- ✅ `curl -I http://127.0.0.1:4000/slides/teams-2025/teams.html`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6945a22c31a48320a850d1180aa6dc97)